### PR TITLE
support for non default Stardew Valley pathes

### DIFF
--- a/build/smapi.targets
+++ b/build/smapi.targets
@@ -30,9 +30,11 @@
     <GamePath Condition="!Exists('$(GamePath)')">$(HOME)/Library/Application Support/Steam/steamapps/common/Stardew Valley/Contents/MacOS</GamePath>
 
     <!-- Windows -->
-    <GamePath Condition="!Exists('$(GamePath)')">C:\Program Files (x86)\GalaxyClient\Games\Stardew Valley</GamePath>
-    <GamePath Condition="!Exists('$(GamePath)')">C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley</GamePath>
-  </PropertyGroup>
+    <GamePath Condition="!Exists('$(GamePath)' )">C:\Program Files (x86)\GalaxyClient\Games\Stardew Valley</GamePath>
+    <GamePath Condition="!Exists('$(GamePath)') AND '$(GamePlatform)' == 'Windows'">$([" >$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\GOG.com\Games\1453375253}', 'PATH', null,RegistryView.Registry64, RegistryView.Registry32))</GamePath>
+    <GamePath Condition="!Exists('$(GamePath)' )">C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley</GamePath>
+    <GamePath Condition="!Exists('$(GamePath)') AND '$(GamePlatform)' == 'Windows'">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 413150', 'InstallLocation', null,RegistryView.Registry64, RegistryView.Registry32))</GamePath>
+ </PropertyGroup>
 
   <!--######
   ## set up configuration


### PR DESCRIPTION
Just added a [MSBuild]::GetRegistryValueFromView check to get SDV game location
Tested on Windows and Linux OpenSuse (it does not break linux build process)