### PR TITLE
Fix PathResolving in buildTask

### DIFF
--- a/build/smapi.targets
+++ b/build/smapi.targets
@@ -32,8 +32,8 @@
     <!-- Windows -->
     <GamePath Condition="!Exists('$(GamePath)' )">C:\Program Files (x86)\GalaxyClient\Games\Stardew Valley</GamePath>
     <GamePath Condition="!Exists('$(GamePath)' )">C:\Program Files (x86)\Steam\steamapps\common\Stardew Valley</GamePath>
-    <GamePath Condition="!Exists('$(GamePath)') AND '$(GamePlatform)' == 'Windows'">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\GOG.com\Games\1453375253@PATH)</GamePath>
-    <GamePath Condition="!Exists('$(GamePath)') AND '$(GamePlatform)' == 'Windows'">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 413150@InstallLocation)</GamePath>
+    <GamePath Condition="!Exists('$(GamePath)') AND '$(GamePlatform)' == 'Windows'">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\GOG.com\Games\1453375253}', 'PATH', null, RegistryView.Registry32))</GamePath>
+    <GamePath Condition="!Exists('$(GamePath)') AND '$(GamePlatform)' == 'Windows'">$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 413150', 'InstallLocation', null,RegistryView.Registry64, RegistryView.Registry32))</GamePath>
   </PropertyGroup>
 
   <!--######


### PR DESCRIPTION
Let MsBuild find steam again.
Also fixed MsBuild wont find Gogs on x86 computer
@Pathoschild can you check if gogs still works on your x64 msBuild?