### PR TITLE
Updates exported mod zip files to use a base folder

### DIFF
--- a/build/smapi.targets
+++ b/build/smapi.targets
@@ -36,7 +36,7 @@
               {
                  // get file info
                  string filePath = file.ItemSpec;
-                 string entryName = file.GetMetadata("RecursiveDir") + file.GetMetadata("Filename") + file.GetMetadata("Extension");
+                 string entryName = ModName + '/' + file.GetMetadata("RecursiveDir") + file.GetMetadata("Filename") + file.GetMetadata("Extension");
                  if (new FileInfo(filePath).Directory.Name.Equals("i18n", StringComparison.InvariantCultureIgnoreCase))
                     entryName = Path.Combine("i18n", entryName);
 


### PR DESCRIPTION
Instead of all of the mod files being in the root directory of the zip file, they are now in /ModName/, making it easier for modders to export upload-ready zip files of their mods.